### PR TITLE
Fix broken link to Adafruit tutorial in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Now we can also write some text:
     >>> oled.show()
 
 Find more information on how to use the SSD1306 on the great [tutorial about
-the OLED featherwing from Adafruit](https://learn.adafruit.com/adafruit-oled-featherwing/circuitpython#usage-6-4).
+the OLED featherwing from Adafruit](https://learn.adafruit.com/adafruit-oled-featherwing/python-usage).


### PR DESCRIPTION
The Adafruit link in the README points to a missing page, this replaces it with a current version of the Python/CircuitPython tutorial for SSD1306.

I couldn't find even a [WaybackMachine version](https://web.archive.org/web/*/https://learn.adafruit.com/adafruit-oled-featherwing/circuitpython) of the link currently in the README, but this new link points to the Python & CircuitPython page from Adafruit with sample code showing how to use the `ssd1306` driver.

P.S. thanks for writing this library!